### PR TITLE
Fix contact links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,8 +64,8 @@ Reports
 Contact
 -------
 
-| `Pierre Dulac <http://github.com/dulaccc>`__
-| [@dulaccc](https://twitter.com/dulaccc)
+| `Pierre Dulac <http://github.com/dulaccc>`_
+| `@dulaccc <https://twitter.com/dulaccc>`_
 
 License
 -------


### PR DESCRIPTION
@dulaccc I noticed that your Twitter handle link wasn't being parsed correctly, so I tweaked it.
